### PR TITLE
Update 1.1.0

### DIFF
--- a/Gateway/Order.php
+++ b/Gateway/Order.php
@@ -25,7 +25,7 @@ class Order
         $order->setStatus(MagentoOrder::STATE_PROCESSING)->save();
 
         /** Send order confirmation e-mail */
-        $this->orderSender->send($order);
+        $this->orderSender->sendMayaConfirmation($order);
     }
 
     public function setAsFailed($order, $paymentId) {

--- a/Gateway/Order.php
+++ b/Gateway/Order.php
@@ -29,7 +29,8 @@ class Order
     }
 
     public function setAsFailed($order, $paymentId) {
-        $order->setState(MagentoOrder::STATE_HOLDED, true)->save();
+        $order->setState(MagentoOrder::STATE_CANCELED, true)->save();
+        $order->setStatus(MagentoOrder::STATE_CANCELED)->save();
         $order->addCommentToStatusHistory("Failed payment {$paymentId}", MagentoOrder::STATE_HOLDED, true)->save();
     }
 

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -10,7 +10,7 @@ class Config
     protected $resourceConfig;
     protected $logger;
 
-    public static $moduleVersion = "1.0.5";
+    public static $moduleVersion = "1.1.0";
 
     public function __construct(
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,

--- a/Model/Order/Email/Sender/OrderSender.php
+++ b/Model/Order/Email/Sender/OrderSender.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace PayMaya\Payment\Model\Order\Email\Sender;
+
+use Magento\Payment\Helper\Data as PaymentHelper;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Email\Container\OrderIdentity;
+use Magento\Sales\Model\Order\Email\Container\Template;
+use Magento\Sales\Model\ResourceModel\Order as OrderResource;
+use Magento\Sales\Model\Order\Address\Renderer;
+use Magento\Framework\Event\ManagerInterface;
+
+use Magento\Sales\Model\Order\Email\Sender\OrderSender as SenderOrderSender;
+
+class OrderSender extends SenderOrderSender {
+    /**
+     * @var PaymentHelper
+     */
+    protected $paymentHelper;
+
+    /**
+     * @var OrderResource
+     */
+    protected $orderResource;
+
+    /**
+     * Global configuration storage.
+     *
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     */
+    protected $globalConfig;
+
+    /**
+     * @var Renderer
+     */
+    protected $addressRenderer;
+
+    /**
+     * Application Event Dispatcher
+     *
+     * @var ManagerInterface
+     */
+    protected $eventManager;
+
+    protected $logger;
+
+    protected $config;
+
+    /**
+     * @param Template $templateContainer
+     * @param OrderIdentity $identityContainer
+     * @param Order\Email\SenderBuilderFactory $senderBuilderFactory
+     * @param \Psr\Log\LoggerInterface $logger
+     * @param Renderer $addressRenderer
+     * @param PaymentHelper $paymentHelper
+     * @param OrderResource $orderResource
+     * @param \Magento\Framework\App\Config\ScopeConfigInterface $globalConfig
+     * @param ManagerInterface $eventManager
+     */
+    public function __construct(
+        Template $templateContainer,
+        OrderIdentity $identityContainer,
+        \Magento\Sales\Model\Order\Email\SenderBuilderFactory $senderBuilderFactory,
+        \Psr\Log\LoggerInterface $logger,
+        Renderer $addressRenderer,
+        PaymentHelper $paymentHelper,
+        OrderResource $orderResource,
+        \Magento\Framework\App\Config\ScopeConfigInterface $globalConfig,
+        ManagerInterface $eventManager,
+        \PayMaya\Payment\Model\Config $config
+    ) {
+        parent::__construct($templateContainer, $identityContainer, $senderBuilderFactory, $logger, $addressRenderer, $paymentHelper, $orderResource, $globalConfig, $eventManager);
+        $this->paymentHelper = $paymentHelper;
+        $this->orderResource = $orderResource;
+        $this->globalConfig = $globalConfig;
+        $this->addressRenderer = $addressRenderer;
+        $this->eventManager = $eventManager;
+        $this->logger = $logger;
+        $this->config = $config;
+    }
+
+    /**
+     * Sends order email to the customer.
+     *
+     * Email will be sent immediately in two cases:
+     *
+     * - if asynchronous email sending is disabled in global settings
+     * - if $forceSyncMode parameter is set to TRUE
+     *
+     * Otherwise, email will be sent later during running of
+     * corresponding cron job.
+     *
+     * @param Order $order
+     * @param bool $forceSyncMode
+     * @return bool
+     */
+    public function send(Order $order, $forceSyncMode = false, $manuallySend = false)
+    {
+        $this->identityContainer->setStore($order->getStore());
+        $order->setSendEmail($this->identityContainer->isEnabled());
+
+        if (!$this->globalConfig->getValue('sales_email/general/async_sending') || $forceSyncMode) {
+            $payment_method = $order->getPayment()->getMethodInstance()->getCode();
+            $send_oc_before_ps = $this->config->getConfigData('paymaya_send_oc_before_ps', 'misc');
+
+            $paidByMaya = $payment_method === 'paymaya_payment';
+
+            if (!$paidByMaya || ($paidByMaya && $manuallySend) || ($paidByMaya && $send_oc_before_ps)) {
+                if ($this->checkAndSend($order)) {
+                    $order->setEmailSent(true);
+                    $this->orderResource->saveAttribute($order, ['send_email', 'email_sent']);
+                    return true;
+                }
+            }
+        } else {
+            $order->setEmailSent(null);
+            $this->orderResource->saveAttribute($order, 'email_sent');
+        }
+
+        $this->orderResource->saveAttribute($order, 'send_email');
+
+        return false;
+    }
+
+    public function sendMayaConfirmation(Order $order, $forceSyncMode = false) {
+        $send_oc_before_ps = $this->config->getConfigData('paymaya_send_oc_before_ps', 'misc');
+
+        if (!$send_oc_before_ps) {
+            $this->send($order, $forceSyncMode, true);
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "paymaya_philippines/paymaya-payment",
     "description": "PayMaya payment method for Magento",
     "type": "magento2-module",
-    "version": "1.0.5",
+    "version": "1.1.0",
     "autoload": {
         "files": ["registration.php"],
         "psr-4": {

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -11,6 +11,7 @@
                 <include path="PayMaya_Payment::system/basic.xml"/>
                 <include path="PayMaya_Payment::system/cards.xml"/>
                 <include path="PayMaya_Payment::system/webhooks.xml"/>
+                <include path="PayMaya_Payment::system/misc.xml"/>
             </group>
         </section>
     </system>

--- a/etc/adminhtml/system/misc.xml
+++ b/etc/adminhtml/system/misc.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
+    <group id="paymaya_misc" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+        <label>Miscellaneous Settings</label>
+        <field id="paymaya_send_oc_before_ps" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Send order confirmation email before payment resolution</label>
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <config_path>payment/paymaya_payment_misc/paymaya_send_oc_before_ps</config_path>
+        </field>
+    </group>
+</include>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -19,6 +19,9 @@
                 <allowspecific>0</allowspecific>
                 <group>paymaya</group>
             </paymaya_payment>
+            <paymaya_payment_misc>
+                <paymaya_send_oc_before_ps>1</paymaya_send_oc_before_ps>
+            </paymaya_payment_misc>
         </payment>
     </default>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -48,6 +48,8 @@
         </arguments>
     </virtualType>
 
+    <preference for="\Magento\Sales\Model\Order\Email\Sender\OrderSender" type="PayMaya\Payment\Model\Order\Email\Sender\OrderSender" />
+
     <!-- Default config value handler -->
     <virtualType name="PayMayaConfigValueHandler" type="Magento\Payment\Gateway\Config\ConfigValueHandler">
         <arguments>


### PR DESCRIPTION
Changes introduced in this PR are the following:

Updates
* Update for marking orders as cancelled instead of on hold if any a payment attempt fails
* Added miscellaneous setting for order confirmation email sending; by default order confirmation emails are sent before payment resolution; setting the configuration to false will wait for a successful payment resolution (via webhooks) before sending the order confirmation email; default behavior is designed accordingly for backwards compatibility

Fixes
* Fixed multiple sending of order confirmation email