### PR TITLE
Fix for unhandled Maya API issues and other enhancements

### DIFF
--- a/Api/PayMayaClient.php
+++ b/Api/PayMayaClient.php
@@ -11,12 +11,15 @@ class PayMayaClient
     const PRODUCTION_BASE_URL = 'https://pg.paymaya.com';
 
     protected $client;
+    protected $config;
+    protected $logger;
+    protected $storeManager;
 
     public function __construct(
         \PayMaya\Payment\Model\Config $config,
         \Magento\Framework\Encryption\EncryptorInterface $encryptor,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
-        \Psr\Log\LoggerInterface $logger
+        \PayMaya\Payment\Logger\Logger $logger
     ) {
         $this->config = $config;
         $this->logger = $logger;
@@ -74,7 +77,7 @@ class PayMayaClient
 
         $payload = $this->formatOrderForPayment($order);
 
-        $this->logger->debug('Payload ' . json_encode($payload));
+        $this->logger->debug('[Create Checkout][Payload]' . json_encode($payload));
 
         $response = $this->client->post('/checkout/v1/checkouts', [
             'json' => $payload,
@@ -91,6 +94,8 @@ class PayMayaClient
     }
 
     private function formatBirthdate($rawBirthDate) {
+        if (!isset($rawBirthDate)) return '';
+
         $time = strtotime($rawBirthDate);
         return date('Y-m-d', $time);
     }
@@ -193,7 +198,6 @@ class PayMayaClient
             "requestReferenceNumber" => $order->getIncrementId(),
         ];
 
-        //echo "<pre>order items: "; print_r($payMayaArray); die;
         return $payMayaArray;
     }
 }

--- a/Controller/Checkout/Catcher.php
+++ b/Controller/Checkout/Catcher.php
@@ -8,6 +8,12 @@ class Catcher extends \Magento\Framework\App\Action\Action
     const CATCH_TYPE_FAIL = 'fail';
     const CATCH_TYPE_CANCEL = 'cancel';
 
+    protected $checkoutHelper;
+    protected $client;
+    protected $request;
+    protected $order;
+    protected $logger;
+
     public function __construct(
         \Magento\Framework\App\Action\Context $context,
         \PayMaya\Payment\Api\PayMayaClient $client,
@@ -27,7 +33,7 @@ class Catcher extends \Magento\Framework\App\Action\Action
 
     public function execute()
     {
-            $catchType = $this->request->getParam('type');
+        $catchType = $this->request->getParam('type');
 
         switch ($catchType) {
             case self::CATCH_TYPE_SUCCESS: {

--- a/Controller/Checkout/Index.php
+++ b/Controller/Checkout/Index.php
@@ -2,13 +2,19 @@
 
 namespace PayMaya\Payment\Controller\Checkout;
 
-class Index  extends \Magento\Framework\App\Action\Action
+use GuzzleHttp\Exception\ClientException;
+
+class Index extends \Magento\Framework\App\Action\Action
 {
+    protected $checkoutSession;
+    protected $client;
+    protected $logger;
+
     public function __construct(
         \Magento\Framework\App\Action\Context $context,
         \PayMaya\Payment\Api\PayMayaClient $client,
         \Magento\Checkout\Model\Session $checkoutSession,
-        \Psr\Log\LoggerInterface $logger
+        \PayMaya\Payment\Logger\Logger $logger
     ) {
         parent::__construct($context);
 
@@ -24,11 +30,19 @@ class Index  extends \Magento\Framework\App\Action\Action
         $order = $this->_objectManager->create(\Magento\Sales\Model\Order::class);
         $order->loadByIncrementId($incrementId);
 
-        $response = $this->client->createCheckout($order);
-        $checkout = json_decode($response, true);
+        try {
+            $response = $this->client->createCheckout($order);
+            $checkout = json_decode($response, true);
 
-        $this->logger->debug('Checkout response ' . $response);
+            $this->logger->debug('[Create Checkout][Response]' . $response);
 
-        $this->_redirect($checkout["redirectUrl"]);
+            $this->_redirect($checkout["redirectUrl"]);
+        } catch (ClientException $e) {
+            $this->logger->error('[Create Checkout]' . $e->getResponse()->getBody()->__toString());
+
+            $this->checkoutSession->restoreQuote();
+            $this->messageManager->addErrorMessage('Something went wrong with the payment');
+            $this->_redirect('checkout/cart');
+        }
     }
 }

--- a/Gateway/Order.php
+++ b/Gateway/Order.php
@@ -2,11 +2,15 @@
 
 namespace PayMaya\Payment\Gateway;
 
+use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Model\Order\Payment\Transaction;
 use Magento\Sales\Model\Order as MagentoOrder;
 
 class Order
 {
+    protected $order;
+    protected $orderSender;
+
     public function __construct(
         \Magento\Sales\Model\Order\Email\Sender\OrderSender $orderSender,
         \Magento\Sales\Api\Data\OrderInterface $order
@@ -35,13 +39,13 @@ class Order
     }
 
     /**
-     * Create transaction records for the order with a PayMongo payment ID
+     * Create transaction records for the order with a Maya payment ID
      */
     public function createTransaction($order, $paymentId) {
         /** Get associated payment model */
         $payment = $order->getPayment();
 
-        /** Set the transaction ID using PayMongo Payment ID */
+        /** Set the transaction ID using Maya ID */
         $payment->setTransactionId($paymentId);
 
         /**
@@ -52,7 +56,7 @@ class Order
 
         /**
          * Don't settle transactions in case of manual refunds since refunds are not
-         * yet available through the PayMongo API
+         * yet available through the extension
          */
         $payment->setIsTransactionClosed(0);
 
@@ -65,7 +69,14 @@ class Order
         /** Save the transaction record */
         $transaction->save();
     }
-
+    
+    /**
+     * loadOrderByIncrementId
+     *
+     * @param  string $orderId
+     * @param  integer $count
+     * @return OrderInterface
+     */
     public function loadOrderByIncrementId($orderId, $count = 7)
     {
         $order = $this->order->loadByIncrementId($orderId);

--- a/Gateway/Webhooks.php
+++ b/Gateway/Webhooks.php
@@ -7,11 +7,16 @@ class Webhooks
     const PAYMENT_SUCCESS = 'paymaya_payment_success_webhook';
     const PAYMENT_FAILED = 'paymaya_payment_failed_webhook';
 
+    protected $cache;
+    protected $logger;
+    protected $request;
+    protected $eventManager;
+
     public function __construct(
         \Magento\Framework\App\CacheInterface $cache,
         \Magento\Framework\Event\ManagerInterface $eventManager,
         \Magento\Framework\App\Request\Http $request,
-        \Psr\Log\LoggerInterface $logger
+        \PayMaya\Payment\Logger\Logger $logger
     ) {
         $this->cache = $cache;
         $this->logger = $logger;
@@ -29,6 +34,8 @@ class Webhooks
             // Retrieve the request's body and parse it as JSON
             $body = $this->request->getContent();
 
+            $this->logger->debug('[Handle Webhook] For ' . $eventType . ' with payload ' . $body);
+
             $payload = json_decode($body, true);
 
             $this->eventManager->dispatch(
@@ -38,11 +45,11 @@ class Webhooks
                 )
             );
 
-            $this->logger->info("200 OK");
+            $this->logger->info("[Handle Webhook] 200 OK");
         }
         catch (\Exception $e)
         {
-            $this->logger->error($e->getMessage());
+            $this->logger->error('[Handle Webhook] ' . $e->getMessage());
         }
     }
 

--- a/Logger/Handler.php
+++ b/Logger/Handler.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PayMaya\Payment\Logger;
+
+use Magento\Framework\Filesystem\DriverInterface;
+
+class Handler extends \Magento\Framework\Logger\Handler\Base
+{
+    protected $filePath = '/var/www/html/var/log/';
+    protected $fileNamePrefix = 'maya-log';
+
+    public function __construct(
+        DriverInterface $filesystem
+    ) {
+        $this->filesystem = $filesystem;
+
+        $fileName = $this->fileNamePrefix . '-' . date('Y-m-d') . '.log';
+
+        parent::__construct(
+            $filesystem,
+            $this->filePath,
+            $fileName,
+        );
+    }
+}

--- a/Logger/Logger.php
+++ b/Logger/Logger.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace PayMaya\Payment\Logger;
+
+class Logger extends \Monolog\Logger {}

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -11,7 +11,7 @@ class Config
     protected $configWriter;
     protected $logger;
 
-    public static $moduleVersion = "1.1.0";
+    public static $moduleVersion = "1.1.1";
 
     public function __construct(
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -8,6 +8,7 @@ class Config
 {
     protected $scopeConfig;
     protected $resourceConfig;
+    protected $configWriter;
     protected $logger;
 
     public static $moduleVersion = "1.1.0";
@@ -26,7 +27,7 @@ class Config
 
     public function isEnabled()
     {
-        $enabled = ((bool)$this->getConfigData('active')) && $this->initPayMaya();
+        $enabled = ((bool)$this->getConfigData('active'));
         return $enabled;
     }
 

--- a/Observer/AdminWebhookRegister.php
+++ b/Observer/AdminWebhookRegister.php
@@ -2,6 +2,7 @@
 
 namespace PayMaya\Payment\Observer;
 
+use GuzzleHttp\Exception\ClientException;
 use Magento\Framework\Event\ObserverInterface;
 
 class AdminWebhookRegister implements ObserverInterface {
@@ -12,7 +13,7 @@ class AdminWebhookRegister implements ObserverInterface {
     protected $overridable_webhooks;
 
     public function __construct(
-        \Psr\Log\LoggerInterface $logger,
+        \PayMaya\Payment\Logger\Logger $logger,
         \PayMaya\Payment\Model\Config $config,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
         \PayMaya\Payment\Api\PayMayaClient $client
@@ -36,22 +37,26 @@ class AdminWebhookRegister implements ObserverInterface {
         $encryptedSecretKey = $this->config->getConfigData("paymaya_{$mode}_sk", 'basic');
 
         if ($this->config->isEnabled() && isset($encryptedSecretKey)) {
-            $body = $this->client->retrieveWebhooks();
-            $webhooks = json_decode($body, true);
-
-            foreach ($webhooks as $webhook) {
-                if (in_array($webhook['name'], $this->overridable_webhooks)) {
-                    $this->client->deleteWebhook($webhook['id']);
+            try {
+                $body = $this->client->retrieveWebhooks();
+                $webhooks = json_decode($body, true);
+    
+                foreach ($webhooks as $webhook) {
+                    if (in_array($webhook['name'], $this->overridable_webhooks)) {
+                        $this->client->deleteWebhook($webhook['id']);
+                    }
                 }
+    
+                $webhookBaseUrl = $this->config->getConfigData('webhook_base_url', 'webhooks');
+    
+                $this->client->createWebhook('CHECKOUT_SUCCESS', "{$webhookBaseUrl}/paymaya/webhooks");
+                $this->client->createWebhook('CHECKOUT_FAILURE', "{$webhookBaseUrl}/paymaya/webhooks");
+                $this->client->createWebhook('PAYMENT_SUCCESS', "{$webhookBaseUrl}/paymaya/webhooks/payment");
+                $this->client->createWebhook('PAYMENT_FAILED', "{$webhookBaseUrl}/paymaya/webhooks/payment");
+                $this->client->createWebhook('PAYMENT_EXPIRED', "{$webhookBaseUrl}/paymaya/webhooks/payment");
+            } catch (ClientException $e) {
+                $this->logger->error('[Register Webhooks] ' . $e->getResponse()->getBody()->__toString());
             }
-
-            $webhookBaseUrl = $this->config->getConfigData('webhook_base_url', 'webhooks');
-
-            $this->client->createWebhook('CHECKOUT_SUCCESS', "{$webhookBaseUrl}/paymaya/webhooks");
-            $this->client->createWebhook('CHECKOUT_FAILURE', "{$webhookBaseUrl}/paymaya/webhooks");
-            $this->client->createWebhook('PAYMENT_SUCCESS', "{$webhookBaseUrl}/paymaya/webhooks/payment");
-            $this->client->createWebhook('PAYMENT_FAILED', "{$webhookBaseUrl}/paymaya/webhooks/payment");
-            $this->client->createWebhook('PAYMENT_EXPIRED', "{$webhookBaseUrl}/paymaya/webhooks/payment");
         }
     }
 }

--- a/Observer/WebhooksObserver.php
+++ b/Observer/WebhooksObserver.php
@@ -4,9 +4,12 @@ namespace PayMaya\Payment\Observer;
 
 class WebhooksObserver implements \Magento\Framework\Event\ObserverInterface
 {
+    protected $logger;
+    protected $orderHelper;
+
     public function __construct(
         \PayMaya\Payment\Gateway\Order $orderHelper,
-        \Psr\Log\LoggerInterface $logger
+        \PayMaya\Payment\Logger\Logger $logger
     ) {
         $this->logger = $logger;
         $this->orderHelper = $orderHelper;

--- a/Setup/Recurring.php
+++ b/Setup/Recurring.php
@@ -12,7 +12,7 @@ class Recurring implements \Magento\Framework\Setup\InstallSchemaInterface
     protected $storeManager;
 
     public function __construct(
-        \Psr\Log\LoggerInterface $logger,
+        \PayMaya\Payment\Logger\Logger $logger,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
         \PayMaya\Payment\Model\Config $config
     ) {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "paymaya_philippines/paymaya-payment",
     "description": "PayMaya payment method for Magento",
     "type": "magento2-module",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "autoload": {
         "files": ["registration.php"],
         "psr-4": {

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -61,4 +61,19 @@
     <type name="Magento\Framework\App\Request\CsrfValidator">
         <plugin name="paymaya_csrf_validator_skip" type="PayMaya\Payment\Plugin\CsrfValidatorSkip" sortOrder="30" />
     </type>
+
+    <type name="PayMaya\Payment\Logger\Handler">
+        <arguments>
+            <argument name="filesystem" xsi:type="object">Magento\Framework\Filesystem\Driver\File</argument>
+        </arguments>
+    </type>
+
+    <type name="PayMaya\Payment\Logger\Logger">
+        <arguments>
+            <argument name="name" xsi:type="string">MayaLogger</argument>
+            <argument name="handlers" xsi:type="array">
+                <item name="system" xsi:type="object">PayMaya\Payment\Logger\Handler</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
This PR introduces the the following:
- Error handlers for any Maya API calls that returns any errors, particularly for creating checkouts
- Introduces a new Logger class that would create a daily log file specific for the Maya extension
- Handle multiple webhook calls for a single order reference -- any paid orders will now be untouched by delayed webhooks associated to it