### PR TITLE
Use internal constants

### DIFF
--- a/Logger/Handler.php
+++ b/Logger/Handler.php
@@ -6,7 +6,7 @@ use Magento\Framework\Filesystem\DriverInterface;
 
 class Handler extends \Magento\Framework\Logger\Handler\Base
 {
-    protected $filePath = '/var/www/html/var/log/';
+    protected $filePath = BP . DIRECTORY_SEPARATOR . 'var/log/';
     protected $fileNamePrefix = 'maya-log';
 
     public function __construct(

--- a/Logger/Handler.php
+++ b/Logger/Handler.php
@@ -6,7 +6,7 @@ use Magento\Framework\Filesystem\DriverInterface;
 
 class Handler extends \Magento\Framework\Logger\Handler\Base
 {
-    protected $filePath = BP . DIRECTORY_SEPARATOR . 'var/log/';
+    protected $filePath = BP . DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . 'log' . DIRECTORY_SEPARATOR;
     protected $fileNamePrefix = 'maya-log';
 
     public function __construct(

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -11,7 +11,7 @@ class Config
     protected $configWriter;
     protected $logger;
 
-    public static $moduleVersion = "1.1.1";
+    public static $moduleVersion = "1.1.2";
 
     public function __construct(
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "paymaya_philippines/paymaya-payment",
     "description": "PayMaya payment method for Magento",
     "type": "magento2-module",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "autoload": {
         "files": ["registration.php"],
         "psr-4": {


### PR DESCRIPTION
In this PR, we've used internal constants defined by Magento to identify the root directory and directory separator to declare the log file directory path